### PR TITLE
chore: set stats to minimal

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -11,6 +11,7 @@ const { resolve } = require('./utils')
 module.exports = {
   mode: 'production',
   entry: resolve('./src/main.js'),
+  stats: 'minimal',
   output: {
     path: resolve('./lib'),
     publicPath: '/lib/',


### PR DESCRIPTION
Avoid excessive log output when the build is complete.